### PR TITLE
Fix building against perl configured with -DDEBUGGING

### DIFF
--- a/XCB.xs
+++ b/XCB.xs
@@ -180,7 +180,7 @@ _connect_and_attach_struct(self)
   PREINIT:
     XCBConnection *xcbconnbuf;
   CODE:
-    assert(sv_derivered_from(self, __PACKAGE__));
+    assert(sv_derivered_from(self, HvNAME(PL_curstash)));
     SV **disp = hv_fetch((HV*)SvRV(self), "display", strlen("display"), 0);
     if(!disp)
         croak("Attribute 'display' is required");

--- a/XCB.xs
+++ b/XCB.xs
@@ -180,7 +180,7 @@ _connect_and_attach_struct(self)
   PREINIT:
     XCBConnection *xcbconnbuf;
   CODE:
-    assert(sv_derivered_from(self, HvNAME(PL_curstash)));
+    assert(sv_derived_from(self, HvNAME(PL_curstash)));
     SV **disp = hv_fetch((HV*)SvRV(self), "display", strlen("display"), 0);
     if(!disp)
         croak("Attribute 'display' is required");


### PR DESCRIPTION
In Gentoo Linux, building X11-XCB-0.190.0 against perl-5.36.0 configured with `-DDEBUGGING` fails with:
```
XCB.xs:183:36: error: '__PACKAGE__' undeclared (first use in this function)
  183 |     assert(sv_derivered_from(self, __PACKAGE__));
      |                                    ^~~~~~~~~~~
```

I don't know much about Perl but from what I gather, `__PACKAGE__` isn't valid in C context.  [This article](https://stackoverflow.com/a/45718129) would seem to suggest `HvNAME(PL_curstash)` would be the C equivalent.

Furthermore, clang-16 will be defaulting to using  `-Wimplicit-function-declaration`.  Using such a default with clang-15, or equivalently using a prerelease of clang-16, building fails with:
```
XCB.xs:183:12: error: call to undeclared function 'sv_derivered_from'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    assert(sv_derivered_from(self, __PACKAGE__));
           ^
```
I would assume `sv_derivered_from` is a typo since I can't find any other reference to it anywhere.  One would reasonably assume `sv_derived_from` was meant.